### PR TITLE
Fix for Windows 10 IoT Core

### DIFF
--- a/NuimoSDK/NuimoBluetoothController.cs
+++ b/NuimoSDK/NuimoBluetoothController.cs
@@ -121,10 +121,8 @@ namespace NuimoSDK
                 case CharacteristicsGuids.FlyCharacteristicGuidString:      nuimoGestureEvent = changedValue.ToFlyEvent();      break;
                 default:                                                    nuimoGestureEvent = null;                           break;
             }
-            if (nuimoGestureEvent != null)
-            {
-                GestureEventOccurred?.Invoke(nuimoGestureEvent);
-            }
+
+            if (nuimoGestureEvent != null) { GestureEventOccurred?.Invoke(nuimoGestureEvent); }
         }
 
         private bool ReadFirmwareVersion()


### PR DESCRIPTION
Patch intended to fix #2 

Remove DispatchOnMainThread (since IoT apps are headless and Dispatcher for the UI thread should be used in the client apps)
Increase CancellationToken for SubscribeForCharacteristicNotifications() (otherwise it would think that connection failed)
