### PR TITLE
Changed all events to include the INuimoController itself as the sender.

### DIFF
--- a/NuimoSDK.sln
+++ b/NuimoSDK.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuimoSDK", "NuimoSDK\NuimoSDK.csproj", "{E1EDA363-0B66-42DC-960F-55941ED96FA4}"
 EndProject

--- a/NuimoSDK/INuimoController.cs
+++ b/NuimoSDK/INuimoController.cs
@@ -5,11 +5,11 @@ namespace NuimoSDK
 {
     public interface INuimoController
     {
-        event Action<NuimoConnectionState> ConnectionStateChanged;
-        event Action<string>               FirmwareVersionRead;
-        event Action                       LedMatrixDisplayed;
-        event Action<int>                  BatteryPercentageChanged;
-        event Action<NuimoGestureEvent>    GestureEventOccurred;
+        event Action<INuimoController, NuimoConnectionState> ConnectionStateChanged;
+        event Action<INuimoController, string>               FirmwareVersionRead;
+        event Action<INuimoController>                       LedMatrixDisplayed;
+        event Action<INuimoController, int>                  BatteryPercentageChanged;
+        event Action<INuimoController, NuimoGestureEvent>    GestureEventOccurred;
 
         string                             Identifier       { get;}
         NuimoConnectionState               ConnectionState  { get;}

--- a/NuimoSDK/NuimoBluetoothController.cs
+++ b/NuimoSDK/NuimoBluetoothController.cs
@@ -26,7 +26,7 @@ namespace NuimoSDK
         private NuimoConnectionState _connectionState = NuimoConnectionState.Disconnected;
         public NuimoConnectionState  ConnectionState {
             get { return _connectionState; }
-            set { _connectionState = value; ConnectionStateChanged?.Invoke(ConnectionState); }
+            set { _connectionState = value; ConnectionStateChanged?.Invoke(this, ConnectionState); }
         }
 
         private readonly BluetoothLEDevice _bluetoothLeDevice;
@@ -108,7 +108,7 @@ namespace NuimoSDK
         {
             if (sender.Uuid.Equals(CharacteristicsGuids.BatteryCharacteristicGuid))
             {
-                BatteryPercentageChanged?.Invoke(changedValue.CharacteristicValue.ToArray()[0]);
+                BatteryPercentageChanged?.Invoke(this, changedValue.CharacteristicValue.ToArray()[0]);
                 return;
             }
 
@@ -122,20 +122,20 @@ namespace NuimoSDK
                 default:                                                    nuimoGestureEvent = null;                           break;
             }
 
-            if (nuimoGestureEvent != null) { GestureEventOccurred?.Invoke(nuimoGestureEvent); }
+            if (nuimoGestureEvent != null) { GestureEventOccurred?.Invoke(this, nuimoGestureEvent); }
         }
 
         private bool ReadFirmwareVersion()
         {
             return ReadCharacteristicValue(CharacteristicsGuids.FirmwareVersionGuid, bytes =>
-                FirmwareVersionRead?.Invoke(Encoding.ASCII.GetString(bytes))
+                FirmwareVersionRead?.Invoke(this, Encoding.ASCII.GetString(bytes))
             );
         }
 
         private bool ReadBatteryLevel()
         {
             return ReadCharacteristicValue(CharacteristicsGuids.BatteryCharacteristicGuid, bytes =>
-                BatteryPercentageChanged?.Invoke(bytes[0])
+                BatteryPercentageChanged?.Invoke(this, bytes[0])
             );
         }
 

--- a/NuimoSDK/NuimoBluetoothController.cs
+++ b/NuimoSDK/NuimoBluetoothController.cs
@@ -14,11 +14,11 @@ namespace NuimoSDK
 {
     public class NuimoBluetoothController : INuimoController
     {
-        public event Action<NuimoConnectionState> ConnectionStateChanged;
-        public event Action<string>               FirmwareVersionRead;
-        public event Action                       LedMatrixDisplayed;
-        public event Action<int>                  BatteryPercentageChanged;
-        public event Action<NuimoGestureEvent>    GestureEventOccurred;
+        public event Action<INuimoController, NuimoConnectionState> ConnectionStateChanged;
+        public event Action<INuimoController, string>               FirmwareVersionRead;
+        public event Action<INuimoController>                       LedMatrixDisplayed;
+        public event Action<INuimoController, int>                  BatteryPercentageChanged;
+        public event Action<INuimoController, NuimoGestureEvent>    GestureEventOccurred;
 
         public string Identifier                    => _bluetoothLeDevice.DeviceId.Substring(14, 12);
         public float  MatrixBrightness { get; set; } = 1.0f;
@@ -177,7 +177,7 @@ namespace NuimoSDK
             {
                 // ReSharper disable once InconsistentlySynchronizedField
                 var gattWriteResponse = await _gattCharacteristicsForGuid[CharacteristicsGuids.LedMatrixCharacteristicGuid].WriteValueAsync(byteArray.AsBuffer(), GattWriteOption.WriteWithResponse);
-                if (gattWriteResponse == GattCommunicationStatus.Success) LedMatrixDisplayed?.Invoke();
+                if (gattWriteResponse == GattCommunicationStatus.Success) LedMatrixDisplayed?.Invoke(this);
             }
         }
 

--- a/NuimoSDK/NuimoBluetoothController.cs
+++ b/NuimoSDK/NuimoBluetoothController.cs
@@ -26,7 +26,7 @@ namespace NuimoSDK
         private NuimoConnectionState _connectionState = NuimoConnectionState.Disconnected;
         public NuimoConnectionState  ConnectionState {
             get { return _connectionState; }
-            set { _connectionState = value; DispatchOnMainAsync(() => ConnectionStateChanged?.Invoke(ConnectionState));}
+            set { _connectionState = value; ConnectionStateChanged?.Invoke(ConnectionState); }
         }
 
         private readonly BluetoothLEDevice _bluetoothLeDevice;
@@ -90,7 +90,7 @@ namespace NuimoSDK
         private bool SubscribeForCharacteristicNotifications()
         {
             var isConnected             = true;
-            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(1000));
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(5000));
             var cancellationToken       = cancellationTokenSource.Token;
             cancellationToken.Register(() => isConnected = false);
 
@@ -108,7 +108,7 @@ namespace NuimoSDK
         {
             if (sender.Uuid.Equals(CharacteristicsGuids.BatteryCharacteristicGuid))
             {
-                DispatchOnMainAsync(() => BatteryPercentageChanged?.Invoke(changedValue.CharacteristicValue.ToArray()[0]));
+                BatteryPercentageChanged?.Invoke(changedValue.CharacteristicValue.ToArray()[0]);
                 return;
             }
 
@@ -121,20 +121,21 @@ namespace NuimoSDK
                 case CharacteristicsGuids.FlyCharacteristicGuidString:      nuimoGestureEvent = changedValue.ToFlyEvent();      break;
                 default:                                                    nuimoGestureEvent = null;                           break;
             }
-            if (nuimoGestureEvent != null) DispatchOnMainAsync(() => GestureEventOccurred?.Invoke(nuimoGestureEvent));
+
+            if (nuimoGestureEvent != null) { GestureEventOccurred?.Invoke(nuimoGestureEvent); }
         }
 
         private bool ReadFirmwareVersion()
         {
             return ReadCharacteristicValue(CharacteristicsGuids.FirmwareVersionGuid, bytes =>
-                DispatchOnMainAsync(() => FirmwareVersionRead?.Invoke(Encoding.ASCII.GetString(bytes)))
+                FirmwareVersionRead?.Invoke(Encoding.ASCII.GetString(bytes))
             );
         }
 
         private bool ReadBatteryLevel()
         {
             return ReadCharacteristicValue(CharacteristicsGuids.BatteryCharacteristicGuid, bytes =>
-                DispatchOnMainAsync(() => BatteryPercentageChanged?.Invoke(bytes[0]))
+                BatteryPercentageChanged?.Invoke(bytes[0])
             );
         }
 
@@ -218,11 +219,6 @@ namespace NuimoSDK
                 }
                 _gattCharacteristicsForGuid.Clear();
             }
-        }
-
-        private async void DispatchOnMainAsync(DispatchedHandler dispatchedHandler)
-        {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, dispatchedHandler);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -36,72 +36,69 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
-class Demo
-{
-	private readonly PairedNuimoManager _pairedNuimoManager = new PairedNuimoManager();
-	private INuimoController _nuimoController;
+    public class Demo
+    {
+        private readonly PairedNuimoManager _pairedNuimoManager = new PairedNuimoManager();
+        private INuimoController _nuimoController;
 
-	private async Task GetPairedNuimos()
-	{
-		var nuimoControllers = await _pairedNuimoManager.ListPairedNuimosAsync();
-		_nuimoController = nuimoControllers.ElementAt(0);
-	}
+        private async void GetPairedNuimos()
+        {
+            var nuimoControllers = await _pairedNuimoManager.ListPairedNuimosAsync();
+            _nuimoController = nuimoControllers.ElementAt(0);
+        }
 
-	private async Task Connect()
-	{
-		var isConnected = await _nuimoController.ConnectAsync();
-	}
+        private async void Connect()
+        {
+            var isConnected = await _nuimoController.ConnectAsync();
+        }
 
-	private void AddDelegates()
-	{
-		_nuimoController.GestureEventOccurred     += OnNuimoGestureEvent;
-		_nuimoController.FirmwareVersionRead      += OnFirmwareVersion;
-		_nuimoController.ConnectionStateChanged   += OnConnectionState;
-		_nuimoController.BatteryPercentageChanged += OnBatteryPercentage;
-		_nuimoController.LedMatrixDisplayed       += OnLedMatrixDisplayed;
-	}
+        private void AddDelegates()
+        {
+            _nuimoController.GestureEventOccurred += OnNuimoGestureEvent;
+            _nuimoController.FirmwareVersionRead += OnFirmwareVersion;
+            _nuimoController.ConnectionStateChanged += OnConnectionState;
+            _nuimoController.BatteryPercentageChanged += OnBatteryPercentage;
+            _nuimoController.LedMatrixDisplayed += OnLedMatrixDisplayed;
+        }
 
-	private void OnNuimoGestureEvent(NuimoGestureEvent nuimoGestureEvent)
-	{
-		Debug.WriteLine("Event: " + nuimoGestureEvent.Gesture + ", " + nuimoGestureEvent.Value);
-	}
+        private void OnNuimoGestureEvent(INuimoController controller, NuimoGestureEvent nuimoGestureEvent)
+        {
+            Debug.WriteLine("Event: " + nuimoGestureEvent.Gesture + ", " + nuimoGestureEvent.Value);
+        }
 
-	private void OnFirmwareVersion(string firmwareVersion)
-	{
-		Debug.WriteLine(firmwareVersion);
-	}
+        private void OnFirmwareVersion(INuimoController controller, string firmwareVersion)
+        {
+            Debug.WriteLine(firmwareVersion);
+        }
 
-	private void OnConnectionState(NuimoConnectionState nuimoConnectionState)
-	{
-		Debug.WriteLine("Connection state: " + nuimoConnectionState);
-	}
+        private void OnConnectionState(INuimoController controller, NuimoConnectionState nuimoConnectionState)
+        {
+            Debug.WriteLine("Connection state: " + nuimoConnectionState);
 
-	private void OnBatteryPercentage(int batteryPercentage)
-	{
-		Debug.WriteLine("Battery percentage: " + batteryPercentage);
-	}
+            var displayInterval = 5.0;
+            var matrixString = "         " +
+                                    "         " +
+                                    " ..   .. " +
+                                    "   . .   " +
+                                    "    .    " +
+                                    "   . .   " +
+                                    " ..   .. " +
+                                    "         " +
+                                    "         ";
+            var options = 2;
+            _nuimoController?.DisplayLedMatrixAsync(new NuimoLedMatrix(matrixString), displayInterval, options);
+        }
 
-	private void OnLedMatrixDisplayed()
-	{
-		Debug.WriteLine("LED matrix displayed");
-	}
+        private void OnBatteryPercentage(INuimoController controller, int batteryPercentage)
+        {
+            Debug.WriteLine("Battery percentage: " + batteryPercentage);
+        }
 
-	private void SendMatrix()
-	{
-		var displayInterval = 5.0;
-		var matrixString =
-			"         " +
-			"         " +
-			" ..   .. " +
-			"   . .   " +
-			"    .    " +
-			"   . .   " +
-			" ..   .. " +
-			"         " +
-			"         ";
-		_nuimoController?.DisplayLedMatrixAsync(new NuimoLedMatrix(matrixString), displayInterval, (int)NuimoLedMatrixWriteOption.WithFadeTransition);
-	}
-}
+        private async void OnLedMatrixDisplayed(INuimoController controller)
+        {
+            Debug.WriteLine("LED matrix displayed");
+        }
+    }
 ```
 
 #### A ready to checkout Windows Universal demo app

--- a/README.md
+++ b/README.md
@@ -33,69 +33,69 @@ The following code example demonstrates how to list paired Nuimos, connect a Nui
 ```C#
 using NuimoSDK;
 
-public class Demo
-{
-    private readonly PairedNuimoManager _pairedNuimoManager = new PairedNuimoManager();
-    private INuimoController _nuimoController;
-
-    private async void GetPairedNuimos()
+    public class Demo
     {
-        var nuimoControllers = await _pairedNuimoManager.ListPairedNuimosAsync();
-        _nuimoController = nuimoControllers.ElementAt(0);
-    }
+        private readonly PairedNuimoManager _pairedNuimoManager = new PairedNuimoManager();
+        private INuimoController _nuimoController;
 
-    private async void Connect()
-    {
-        var isConnected = await _nuimoController.ConnectAsync();
-    }
+        private async void GetPairedNuimos()
+        {
+            var nuimoControllers = await _pairedNuimoManager.ListPairedNuimosAsync();
+            _nuimoController = nuimoControllers.ElementAt(0);
+        }
 
-    private void AddDelegates()
-    {
-        _nuimoController.GestureEventOccurred += OnNuimoGestureEvent;
-        _nuimoController.FirmwareVersionRead += OnFirmwareVersion;
-        _nuimoController.ConnectionStateChanged += OnConnectionState;
-        _nuimoController.BatteryPercentageChanged += OnBatteryPercentage;
-        _nuimoController.LedMatrixDisplayed += OnLedMatrixDisplayed;
-    }
+        private async void Connect()
+        {
+            var isConnected = await _nuimoController.ConnectAsync();
+        }
 
-    private void OnNuimoGestureEvent(NuimoGestureEvent nuimoGestureEvent)
-    {
-        Debug.WriteLine("Event: " + nuimoGestureEvent.Gesture + ", " + nuimoGestureEvent.Value);
-    }
+        private void AddDelegates()
+        {
+            _nuimoController.GestureEventOccurred += OnNuimoGestureEvent;
+            _nuimoController.FirmwareVersionRead += OnFirmwareVersion;
+            _nuimoController.ConnectionStateChanged += OnConnectionState;
+            _nuimoController.BatteryPercentageChanged += OnBatteryPercentage;
+            _nuimoController.LedMatrixDisplayed += OnLedMatrixDisplayed;
+        }
 
-    private void OnFirmwareVersion(string firmwareVersion)
-    {
-        Debug.WriteLine(firmwareVersion);
-    }
+        private void OnNuimoGestureEvent(INuimoController controller, NuimoGestureEvent nuimoGestureEvent)
+        {
+            Debug.WriteLine("Event: " + nuimoGestureEvent.Gesture + ", " + nuimoGestureEvent.Value);
+        }
 
-    private void OnConnectionState(NuimoConnectionState nuimoConnectionState)
-    {
-        Debug.WriteLine("Connection state: " + nuimoConnectionState);
+        private void OnFirmwareVersion(INuimoController controller, string firmwareVersion)
+        {
+            Debug.WriteLine(firmwareVersion);
+        }
 
-        var displayInterval = 5.0;
-        var matrixString =      "         " +
-                                "         " +
-                                " ..   .. " +
-                                "   . .   " +
-                                "    .    " +
-                                "   . .   " +
-                                " ..   .. " +
-                                "         " +
-                                "         ";
-        var options = 2;
-        _nuimoController?.DisplayLedMatrixAsync(new NuimoLedMatrix(matrixString), displayInterval, options);
-    }
+        private void OnConnectionState(INuimoController controller, NuimoConnectionState nuimoConnectionState)
+        {
+            Debug.WriteLine("Connection state: " + nuimoConnectionState);
 
-    private void OnBatteryPercentage(int batteryPercentage)
-    {
-        Debug.WriteLine("Battery percentage: " + batteryPercentage);
-    }
+            var displayInterval = 5.0;
+            var matrixString = "         " +
+                                    "         " +
+                                    " ..   .. " +
+                                    "   . .   " +
+                                    "    .    " +
+                                    "   . .   " +
+                                    " ..   .. " +
+                                    "         " +
+                                    "         ";
+            var options = 2;
+            _nuimoController?.DisplayLedMatrixAsync(new NuimoLedMatrix(matrixString), displayInterval, options);
+        }
 
-    private async void OnLedMatrixDisplayed()
-    {
-        Debug.WriteLine("LED matrix displayed");
+        private void OnBatteryPercentage(INuimoController controller, int batteryPercentage)
+        {
+            Debug.WriteLine("Battery percentage: " + batteryPercentage);
+        }
+
+        private async void OnLedMatrixDisplayed(INuimoController controller)
+        {
+            Debug.WriteLine("LED matrix displayed");
+        }
     }
-}
 ```
 
 #### A ready to checkout Windows Universal demo app

--- a/README.md
+++ b/README.md
@@ -36,69 +36,69 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
-    public class Demo
-    {
-        private readonly PairedNuimoManager _pairedNuimoManager = new PairedNuimoManager();
-        private INuimoController _nuimoController;
+public class Demo
+{
+	private readonly PairedNuimoManager _pairedNuimoManager = new PairedNuimoManager();
+	private INuimoController _nuimoController;
 
-        private async void GetPairedNuimos()
-        {
-            var nuimoControllers = await _pairedNuimoManager.ListPairedNuimosAsync();
-            _nuimoController = nuimoControllers.ElementAt(0);
-        }
+	private async void GetPairedNuimos()
+	{
+		var nuimoControllers = await _pairedNuimoManager.ListPairedNuimosAsync();
+		_nuimoController = nuimoControllers.ElementAt(0);
+	}
 
-        private async void Connect()
-        {
-            var isConnected = await _nuimoController.ConnectAsync();
-        }
+	private async void Connect()
+	{
+		var isConnected = await _nuimoController.ConnectAsync();
+	}
 
-        private void AddDelegates()
-        {
-            _nuimoController.GestureEventOccurred += OnNuimoGestureEvent;
-            _nuimoController.FirmwareVersionRead += OnFirmwareVersion;
-            _nuimoController.ConnectionStateChanged += OnConnectionState;
-            _nuimoController.BatteryPercentageChanged += OnBatteryPercentage;
-            _nuimoController.LedMatrixDisplayed += OnLedMatrixDisplayed;
-        }
+	private void AddDelegates()
+	{
+		_nuimoController.GestureEventOccurred += OnNuimoGestureEvent;
+		_nuimoController.FirmwareVersionRead += OnFirmwareVersion;
+		_nuimoController.ConnectionStateChanged += OnConnectionState;
+		_nuimoController.BatteryPercentageChanged += OnBatteryPercentage;
+		_nuimoController.LedMatrixDisplayed += OnLedMatrixDisplayed;
+	}
 
-        private void OnNuimoGestureEvent(INuimoController controller, NuimoGestureEvent nuimoGestureEvent)
-        {
-            Debug.WriteLine("Event: " + nuimoGestureEvent.Gesture + ", " + nuimoGestureEvent.Value);
-        }
+	private void OnNuimoGestureEvent(INuimoController controller, NuimoGestureEvent nuimoGestureEvent)
+	{
+		Debug.WriteLine("Event: " + nuimoGestureEvent.Gesture + ", " + nuimoGestureEvent.Value);
+	}
 
-        private void OnFirmwareVersion(INuimoController controller, string firmwareVersion)
-        {
-            Debug.WriteLine(firmwareVersion);
-        }
+	private void OnFirmwareVersion(INuimoController controller, string firmwareVersion)
+	{
+		Debug.WriteLine(firmwareVersion);
+	}
 
-        private void OnConnectionState(INuimoController controller, NuimoConnectionState nuimoConnectionState)
-        {
-            Debug.WriteLine("Connection state: " + nuimoConnectionState);
+	private void OnConnectionState(INuimoController controller, NuimoConnectionState nuimoConnectionState)
+	{
+		Debug.WriteLine("Connection state: " + nuimoConnectionState);
 
-            var displayInterval = 5.0;
-            var matrixString = "         " +
-                                    "         " +
-                                    " ..   .. " +
-                                    "   . .   " +
-                                    "    .    " +
-                                    "   . .   " +
-                                    " ..   .. " +
-                                    "         " +
-                                    "         ";
-            var options = 2;
-            _nuimoController?.DisplayLedMatrixAsync(new NuimoLedMatrix(matrixString), displayInterval, options);
-        }
+		var displayInterval = 5.0;
+		var matrixString = "         " +
+								"         " +
+								" ..   .. " +
+								"   . .   " +
+								"    .    " +
+								"   . .   " +
+								" ..   .. " +
+								"         " +
+								"         ";
+		var options = 2;
+		_nuimoController?.DisplayLedMatrixAsync(new NuimoLedMatrix(matrixString), displayInterval, options);
+	}
 
-        private void OnBatteryPercentage(INuimoController controller, int batteryPercentage)
-        {
-            Debug.WriteLine("Battery percentage: " + batteryPercentage);
-        }
+	private void OnBatteryPercentage(INuimoController controller, int batteryPercentage)
+	{
+		Debug.WriteLine("Battery percentage: " + batteryPercentage);
+	}
 
-        private async void OnLedMatrixDisplayed(INuimoController controller)
-        {
-            Debug.WriteLine("LED matrix displayed");
-        }
-    }
+	private async void OnLedMatrixDisplayed(INuimoController controller)
+	{
+		Debug.WriteLine("LED matrix displayed");
+	}
+}
 ```
 
 #### A ready to checkout Windows Universal demo app


### PR DESCRIPTION
It's good practice for events to include a sender object, so the listening object can know which nuimo device actually fired the event (in case of multiple devices). I've added an INuimoController parameter to all events, and call them with this as the parameter. That way, if a class is subscribed to events on multiple devices, it will always know which one fired the event.
