### PR TITLE
Get Battery and Firmware version on request

### DIFF
--- a/NuimoSDK.sln
+++ b/NuimoSDK.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuimoSDK", "NuimoSDK\NuimoSDK.csproj", "{E1EDA363-0B66-42DC-960F-55941ED96FA4}"
 EndProject

--- a/NuimoSDK/INuimoController.cs
+++ b/NuimoSDK/INuimoController.cs
@@ -19,7 +19,7 @@ namespace NuimoSDK
         Task<bool> DisconnectAsync();
 
         void DisplayLedMatrixAsync(NuimoLedMatrix matrix, double displayInterval = 2.0, int options = 0);
-        string GetFirmwareVersion();
+        bool GetFirmwareVersion(out string firmwareVersion);
         bool GetBatteryLevel(out int batteryLevel);
     }
 

--- a/NuimoSDK/INuimoController.cs
+++ b/NuimoSDK/INuimoController.cs
@@ -19,6 +19,8 @@ namespace NuimoSDK
         Task<bool> DisconnectAsync();
 
         void DisplayLedMatrixAsync(NuimoLedMatrix matrix, double displayInterval = 2.0, int options = 0);
+        string GetFirmwareVersion();
+        bool GetBatteryLevel(out int batteryLevel);
     }
 
     public enum NuimoConnectionState

--- a/NuimoSDK/NuimoBluetoothController.cs
+++ b/NuimoSDK/NuimoBluetoothController.cs
@@ -138,6 +138,23 @@ namespace NuimoSDK
             );
         }
 
+        public bool GetBatteryLevel(out int batteryLevel)
+        {
+            var battLvl = 0;
+            var success = ReadCharacteristicValue(CharacteristicsGuids.BatteryCharacteristicGuid, bytes => battLvl = bytes[0]);
+            batteryLevel = battLvl;
+            return success;
+        }
+
+        public bool GetFirmwareVersion(out string firmwareVersion)
+        {
+            string fwVer = null;
+            var success = ReadCharacteristicValue(CharacteristicsGuids.FirmwareVersionGuid,
+                bytes => fwVer = Encoding.ASCII.GetString(bytes));
+            firmwareVersion = fwVer;
+            return success;
+        }
+
         private bool ReadCharacteristicValue(Guid characteristicGuid, Action<byte[]> onValueRead)
         {
             var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(1000));


### PR DESCRIPTION
Currently, the only way to get firmware version is by hooking up to the get firmware event. One could argue that it makes sense, since it doesn't change during a connection session (device needs to reboot and reconnect to update). But for battery it's the same (except there's an event to get notified of changes). But I would like to be able to request battery level (and for the sake of completion, I just added firmware too). I see no reason why these methods should not be available for public consumption (unless requesting current battery % is a very expensive operation that should really be limited to only once per session).
