### PR TITLE
Use enum flags instead of an int bit operation

### DIFF
--- a/NuimoSDK/INuimoController.cs
+++ b/NuimoSDK/INuimoController.cs
@@ -18,7 +18,7 @@ namespace NuimoSDK
         Task<bool> ConnectAsync();
         Task<bool> DisconnectAsync();
 
-        void DisplayLedMatrixAsync(NuimoLedMatrix matrix, double displayInterval = 2.0, int options = 0);
+        void DisplayLedMatrixAsync(NuimoLedMatrix matrix, double displayInterval = 2.0, NuimoLedMatrixWriteOption options = NuimoLedMatrixWriteOption.None);
     }
 
     public enum NuimoConnectionState
@@ -28,9 +28,11 @@ namespace NuimoSDK
         Connected,
         Disconnecting,
     }
-
+    
+    [Flags]
     public enum NuimoLedMatrixWriteOption
     {
+        None                 = 0,
         WithFadeTransition   = 1,
         WithoutWriteResponse = 2
     }

--- a/NuimoSDK/INuimoController.cs
+++ b/NuimoSDK/INuimoController.cs
@@ -18,7 +18,7 @@ namespace NuimoSDK
         Task<bool> ConnectAsync();
         Task<bool> DisconnectAsync();
 
-        void DisplayLedMatrixAsync(NuimoLedMatrix matrix, double displayInterval = 2.0, NuimoLedMatrixWriteOption options = NuimoLedMatrixWriteOption.None);
+        void DisplayLedMatrixAsync(NuimoLedMatrix matrix, double displayInterval = 2.0, NuimoLedMatrixWriteOptions options = NuimoLedMatrixWriteOptions.None);
     }
 
     public enum NuimoConnectionState
@@ -30,7 +30,7 @@ namespace NuimoSDK
     }
     
     [Flags]
-    public enum NuimoLedMatrixWriteOption
+    public enum NuimoLedMatrixWriteOptions
     {
         None                 = 0,
         WithFadeTransition   = 1,

--- a/NuimoSDK/NuimoBluetoothController.cs
+++ b/NuimoSDK/NuimoBluetoothController.cs
@@ -153,12 +153,12 @@ namespace NuimoSDK
             return !readResult.IsCanceled;
         }
 
-        public async void DisplayLedMatrixAsync(NuimoLedMatrix matrix, double displayInterval = 2.0, int options = 0)
+        public async void DisplayLedMatrixAsync(NuimoLedMatrix matrix, double displayInterval = 2.0, NuimoLedMatrixWriteOption options = NuimoLedMatrixWriteOption.None)
         {
             if (ConnectionState != NuimoConnectionState.Connected) return;
 
-            var withFadeTransition   = (options & (int) NuimoLedMatrixWriteOption.WithFadeTransition)   != 0;
-            var writeWithoutResponse = (options & (int) NuimoLedMatrixWriteOption.WithoutWriteResponse) != 0;
+            var withFadeTransition   = options.HasFlag(NuimoLedMatrixWriteOption.WithFadeTransition);
+            var writeWithoutResponse = options.HasFlag(NuimoLedMatrixWriteOption.WithoutWriteResponse);
 
             var byteArray = new byte[13];
             matrix.GattBytes().CopyTo(byteArray, 0);

--- a/NuimoSDK/NuimoBluetoothController.cs
+++ b/NuimoSDK/NuimoBluetoothController.cs
@@ -153,12 +153,12 @@ namespace NuimoSDK
             return !readResult.IsCanceled;
         }
 
-        public async void DisplayLedMatrixAsync(NuimoLedMatrix matrix, double displayInterval = 2.0, NuimoLedMatrixWriteOption options = NuimoLedMatrixWriteOption.None)
+        public async void DisplayLedMatrixAsync(NuimoLedMatrix matrix, double displayInterval = 2.0, NuimoLedMatrixWriteOptions options = NuimoLedMatrixWriteOptions.None)
         {
             if (ConnectionState != NuimoConnectionState.Connected) return;
 
-            var withFadeTransition   = options.HasFlag(NuimoLedMatrixWriteOption.WithFadeTransition);
-            var writeWithoutResponse = options.HasFlag(NuimoLedMatrixWriteOption.WithoutWriteResponse);
+            var withFadeTransition   = options.HasFlag(NuimoLedMatrixWriteOptions.WithFadeTransition);
+            var writeWithoutResponse = options.HasFlag(NuimoLedMatrixWriteOptions.WithoutWriteResponse);
 
             var byteArray = new byte[13];
             matrix.GattBytes().CopyTo(byteArray, 0);

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ class Demo
 			" ..   .. " +
 			"         " +
 			"         ";
-		_nuimoController?.DisplayLedMatrixAsync(new NuimoLedMatrix(matrixString), displayInterval, (int)NuimoLedMatrixWriteOption.WithFadeTransition);
+		_nuimoController?.DisplayLedMatrixAsync(new NuimoLedMatrix(matrixString), displayInterval, NuimoLedMatrixWriteOption.WithFadeTransition);
 	}
 }
 ```


### PR DESCRIPTION
The code becomes more readable and better typed if you use enum flags instead of the int values construction.

See https://msdn.microsoft.com/en-us/library/cc138362.aspx#Anchor_0 for more info.
