### PR TITLE
Include sender in events

### DIFF
--- a/NuimoSDK/INuimoController.cs
+++ b/NuimoSDK/INuimoController.cs
@@ -5,11 +5,11 @@ namespace NuimoSDK
 {
     public interface INuimoController
     {
-        event Action<NuimoConnectionState> ConnectionStateChanged;
-        event Action<string>               FirmwareVersionRead;
-        event Action                       LedMatrixDisplayed;
-        event Action<int>                  BatteryPercentageChanged;
-        event Action<NuimoGestureEvent>    GestureEventOccurred;
+        event Action<INuimoController, NuimoConnectionState> ConnectionStateChanged;
+        event Action<INuimoController, string>               FirmwareVersionRead;
+        event Action<INuimoController>                       LedMatrixDisplayed;
+        event Action<INuimoController, int>                  BatteryPercentageChanged;
+        event Action<INuimoController, NuimoGestureEvent>    GestureEventOccurred;
 
         string                             Identifier       { get;}
         NuimoConnectionState               ConnectionState  { get;}

--- a/NuimoSDK/NuimoBluetoothController.cs
+++ b/NuimoSDK/NuimoBluetoothController.cs
@@ -14,11 +14,11 @@ namespace NuimoSDK
 {
     public class NuimoBluetoothController : INuimoController
     {
-        public event Action<NuimoConnectionState> ConnectionStateChanged;
-        public event Action<string>               FirmwareVersionRead;
-        public event Action                       LedMatrixDisplayed;
-        public event Action<int>                  BatteryPercentageChanged;
-        public event Action<NuimoGestureEvent>    GestureEventOccurred;
+        public event Action<INuimoController, NuimoConnectionState> ConnectionStateChanged;
+        public event Action<INuimoController, string>               FirmwareVersionRead;
+        public event Action<INuimoController>                       LedMatrixDisplayed;
+        public event Action<INuimoController, int>                  BatteryPercentageChanged;
+        public event Action<INuimoController, NuimoGestureEvent>    GestureEventOccurred;
 
         public string Identifier                    => _bluetoothLeDevice.DeviceId.Substring(14, 12);
         public float  MatrixBrightness { get; set; } = 1.0f;
@@ -26,7 +26,7 @@ namespace NuimoSDK
         private NuimoConnectionState _connectionState = NuimoConnectionState.Disconnected;
         public NuimoConnectionState  ConnectionState {
             get { return _connectionState; }
-            set { _connectionState = value; ConnectionStateChanged?.Invoke(ConnectionState); }
+            set { _connectionState = value; ConnectionStateChanged?.Invoke(this, ConnectionState); }
         }
 
         private readonly BluetoothLEDevice _bluetoothLeDevice;
@@ -108,7 +108,7 @@ namespace NuimoSDK
         {
             if (sender.Uuid.Equals(CharacteristicsGuids.BatteryCharacteristicGuid))
             {
-                BatteryPercentageChanged?.Invoke(changedValue.CharacteristicValue.ToArray()[0]);
+                BatteryPercentageChanged?.Invoke(this, changedValue.CharacteristicValue.ToArray()[0]);
                 return;
             }
 
@@ -122,20 +122,20 @@ namespace NuimoSDK
                 default:                                                    nuimoGestureEvent = null;                           break;
             }
 
-            if (nuimoGestureEvent != null) { GestureEventOccurred?.Invoke(nuimoGestureEvent); }
+            if (nuimoGestureEvent != null) { GestureEventOccurred?.Invoke(this, nuimoGestureEvent); }
         }
 
         private bool ReadFirmwareVersion()
         {
             return ReadCharacteristicValue(CharacteristicsGuids.FirmwareVersionGuid, bytes =>
-                FirmwareVersionRead?.Invoke(Encoding.GetEncoding("ASCII").GetString(bytes, 0, bytes.Length))
+                FirmwareVersionRead?.Invoke(this, Encoding.GetEncoding("ASCII").GetString(bytes, 0, bytes.Length))
             );
         }
 
         private bool ReadBatteryLevel()
         {
             return ReadCharacteristicValue(CharacteristicsGuids.BatteryCharacteristicGuid, bytes =>
-                BatteryPercentageChanged?.Invoke(bytes[0])
+                BatteryPercentageChanged?.Invoke(this, bytes[0])
             );
         }
 
@@ -177,7 +177,7 @@ namespace NuimoSDK
             {
                 // ReSharper disable once InconsistentlySynchronizedField
                 var gattWriteResponse = await _gattCharacteristicsForGuid[CharacteristicsGuids.LedMatrixCharacteristicGuid].WriteValueAsync(byteArray.AsBuffer(), GattWriteOption.WriteWithResponse);
-                if (gattWriteResponse == GattCommunicationStatus.Success) LedMatrixDisplayed?.Invoke();
+                if (gattWriteResponse == GattCommunicationStatus.Success) LedMatrixDisplayed?.Invoke(this);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -61,27 +61,27 @@ class Demo
 		_nuimoController.LedMatrixDisplayed       += OnLedMatrixDisplayed;
 	}
 
-	private void OnNuimoGestureEvent(NuimoGestureEvent nuimoGestureEvent)
+	private void OnNuimoGestureEvent(INuimoController sender, NuimoGestureEvent nuimoGestureEvent)
 	{
 		Debug.WriteLine("Event: " + nuimoGestureEvent.Gesture + ", " + nuimoGestureEvent.Value);
 	}
 
-	private void OnFirmwareVersion(string firmwareVersion)
+	private void OnFirmwareVersion(INuimoController sender, string firmwareVersion)
 	{
 		Debug.WriteLine(firmwareVersion);
 	}
 
-	private void OnConnectionState(NuimoConnectionState nuimoConnectionState)
+	private void OnConnectionState(INuimoController sender, NuimoConnectionState nuimoConnectionState)
 	{
 		Debug.WriteLine("Connection state: " + nuimoConnectionState);
 	}
 
-	private void OnBatteryPercentage(int batteryPercentage)
+	private void OnBatteryPercentage(INuimoController sender, int batteryPercentage)
 	{
 		Debug.WriteLine("Battery percentage: " + batteryPercentage);
 	}
 
-	private void OnLedMatrixDisplayed()
+	private void OnLedMatrixDisplayed(INuimoController sender)
 	{
 		Debug.WriteLine("LED matrix displayed");
 	}


### PR DESCRIPTION
Good practice to include sender in events. Also makes it easier to write applications that support multiple Nuimo-devices.
